### PR TITLE
Patch v0.2.0 -> v0.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rlandfire
 Type: Package
 Title: Tools for Accessing and Working with LANDFIRE
-Version: 0.2.0
+Version: 0.2.1
 Author:
   c(person(given = "Mark",
            family = "Buckner",

--- a/R/getAOI.R
+++ b/R/getAOI.R
@@ -33,5 +33,6 @@ getAOI <- function(data, extend = NULL) {
   if(sf::st_crs(data) != sf::st_crs(4326)) {
     ext <- terra::project(ext, sf::st_crs(data)$wkt, sf::st_crs(4326)$wkt)
   }
-  as.vector(ext)
+  as.vector(c(ext$xmin, ext$ymin, ext$xmax, ext$ymax))
 }
+

--- a/R/getAOI.R
+++ b/R/getAOI.R
@@ -9,6 +9,8 @@
 #'
 #' @return Returns an extent vector ordered `xmin`, `ymin`, `xmax`, `ymax`
 #'    with a lat/lon projection.
+#'
+#' @md
 #' @export
 #'
 #' @examples

--- a/R/landfireAPI.R
+++ b/R/landfireAPI.R
@@ -46,7 +46,7 @@
 
 landfireAPI <- function(products, aoi, projection = NULL, resolution = NULL,
                         edit_rule = NULL, edit_mask = NULL, path = NULL,
-                        max_time = 1000, method = "curl", verbose = TRUE) {
+                        max_time = 10000, method = "curl", verbose = TRUE) {
 
   #### Checks
   # Missing
@@ -96,7 +96,9 @@ landfireAPI <- function(products, aoi, projection = NULL, resolution = NULL,
   # Check it is sf or spatvector
 
   # Values in range
-  if(resolution == 30) resolution <- NULL
+  if(is.numeric(resolution) && resolution == 30) {
+    resolution <- NULL
+  }
 
   #### End Checks
 

--- a/R/landfireAPI.R
+++ b/R/landfireAPI.R
@@ -4,7 +4,7 @@
 #' `landfireAPI` downloads LANDFIRE data by calling the LFPS API
 #'
 #' @param products Product names as character vector
-#'   (see: [https://lfps.usgs.gov/helpdocs/productstable.html])
+#'   (see: \href{https://lfps.usgs.gov/helpdocs/productstable.html}{Products Table})
 #' @param aoi Area of interest as character or numeric vector defined by
 #'   latitude and longitude in decimal degrees in WGS84 and ordered
 #'   `xmin`, `ymin`, `xmax`, `ymax` or a LANDFIRE map zone.
@@ -14,7 +14,7 @@
 #'   resample resolution in meters. Default is 30m.
 #' @param edit_rule Optional. A list of character vectors ordered "operator class"
 #'   "product", "operator", "value". Limited to fuel theme products only.
-#'   (see: [https://lfps.usgs.gov/helpdocs/LFProductsServiceUserGuide.pdf])
+#'   (see: \href{https://lfps.usgs.gov/helpdocs/LFProductsServiceUserGuide.pdf}{LFPS Guide})
 #' @param edit_mask Optional. **Not currently functional**
 #' @param path Path to `.zip` directory. Passed to [utils::download.file()].
 #'   If NULL, a temporary directory is created.
@@ -22,7 +22,15 @@
 #' @param method Passed to [utils::download.file()]. See `?download.file`
 #' @param verbose If FALSE suppress all status messages
 #'
-#' @return Returns API call passed from [httr::get()]. Downloads files to `path`
+#' @return
+#' Returns a `landfire_api` object with named elements:
+#' * `request` - list with elements `query`, `date`, `url`, `job_id`,`dwl_url`
+#' * `content` - Informative messages passed from API
+#' * `response` - Full response
+#' * `status` - Final API status, one of "Failed", "Succeeded", or "Timed out"
+#' * `path` - path to save directory
+#'
+#' @md
 #' @export
 #'
 #' @examples

--- a/R/landfireAPI.R
+++ b/R/landfireAPI.R
@@ -87,6 +87,9 @@ landfireAPI <- function(products, aoi, projection = NULL, resolution = NULL,
   # grepl('[^[:alnum:]]', val)
   # Check it is sf or spatvector
 
+  # Values in range
+  if(resolution == 30) resolution <- NULL
+
   #### End Checks
 
   if(!is.null(edit_rule)) {

--- a/man/getAOI.Rd
+++ b/man/getAOI.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/getAOI.R
 \name{getAOI}
 \alias{getAOI}
-\title{Create extent vector for `landfireAPI()`}
+\title{Create extent vector for \code{landfireAPI()}}
 \usage{
 getAOI(data, extend = NULL)
 }
@@ -10,14 +10,14 @@ getAOI(data, extend = NULL)
 \item{data}{A SpatRaster, SpatVector, sf, stars, or RasterLayer (raster) object}
 
 \item{extend}{Optional. A numeric vector of 1, 2, or 4 elements passed to
-[terra::extend()] by which to increase the extent by.}
+\code{\link[terra:extend]{terra::extend()}} by which to increase the extent by.}
 }
 \value{
-Returns an extent vector ordered `xmin`, `ymin`, `xmax`, `ymax`
-   with a lat/lon projection.
+Returns an extent vector ordered \code{xmin}, \code{ymin}, \code{xmax}, \code{ymax}
+with a lat/lon projection.
 }
 \description{
-`getAOI` creates and extent vector in WGS84 from spatial data
+\code{getAOI} creates and extent vector in WGS84 from spatial data
 }
 \examples{
 r <- terra::rast(nrows = 50, ncols = 50, xmin = -30, xmax = 10, ymin = -30,

--- a/man/landfireAPI.Rd
+++ b/man/landfireAPI.Rd
@@ -19,11 +19,11 @@ landfireAPI(
 }
 \arguments{
 \item{products}{Product names as character vector
-(see: [https://lfps.usgs.gov/helpdocs/productstable.html])}
+(see: \href{https://lfps.usgs.gov/helpdocs/productstable.html}{Products Table})}
 
 \item{aoi}{Area of interest as character or numeric vector defined by
 latitude and longitude in decimal degrees in WGS84 and ordered
-`xmin`, `ymin`, `xmax`, `ymax` or a LANDFIRE map zone.}
+\code{xmin}, \code{ymin}, \code{xmax}, \code{ymax} or a LANDFIRE map zone.}
 
 \item{projection}{Optional. A numeric value of the WKID for the output projection
 Default is a localized Albers projection.}
@@ -33,24 +33,31 @@ resample resolution in meters. Default is 30m.}
 
 \item{edit_rule}{Optional. A list of character vectors ordered "operator class"
 "product", "operator", "value". Limited to fuel theme products only.
-(see: [https://lfps.usgs.gov/helpdocs/LFProductsServiceUserGuide.pdf])}
+(see: \href{https://lfps.usgs.gov/helpdocs/LFProductsServiceUserGuide.pdf}{LFPS Guide})}
 
-\item{edit_mask}{Optional. **Not currently functional**}
+\item{edit_mask}{Optional. \strong{Not currently functional}}
 
-\item{path}{Path to `.zip` directory. Passed to [utils::download.file()].
+\item{path}{Path to \code{.zip} directory. Passed to \code{\link[utils:download.file]{utils::download.file()}}.
 If NULL, a temporary directory is created.}
 
 \item{max_time}{Maximum time, in seconds, to wait for job to be completed.}
 
-\item{method}{Passed to [utils::download.file()]. See `?download.file`}
+\item{method}{Passed to \code{\link[utils:download.file]{utils::download.file()}}. See \code{?download.file}}
 
 \item{verbose}{If FALSE suppress all status messages}
 }
 \value{
-Returns API call passed from [httr::get()]. Downloads files to `path`
+Returns a \code{landfire_api} object with named elements:
+\itemize{
+\item \code{request} - list with elements \code{query}, \code{date}, \code{url}, \code{job_id},\code{dwl_url}
+\item \code{content} - Informative messages passed from API
+\item \code{response} - Full response
+\item \code{status} - Final API status, one of "Failed", "Succeeded", or "Timed out"
+\item \code{path} - path to save directory
+}
 }
 \description{
-`landfireAPI` downloads LANDFIRE data by calling the LFPS API
+\code{landfireAPI} downloads LANDFIRE data by calling the LFPS API
 }
 \examples{
 \dontrun{

--- a/man/landfireAPI.Rd
+++ b/man/landfireAPI.Rd
@@ -12,7 +12,7 @@ landfireAPI(
   edit_rule = NULL,
   edit_mask = NULL,
   path = NULL,
-  max_time = 1000,
+  max_time = 10000,
   method = "curl",
   verbose = TRUE
 )

--- a/tests/testthat/test-getAOI.R
+++ b/tests/testthat/test-getAOI.R
@@ -1,11 +1,12 @@
 test_that("`getAOI` works with supported object classes", {
   r <- terra::rast(nrows = 50, ncols = 50,
-                   xmin = -30, xmax = 10,
-                   ymin = -30, ymax = 10,
+                   xmin = -123.7835, xmax = -123.6352,
+                   ymin = 41.7534, ymax = 41.8042,
                    crs = terra::crs("epsg:4326"),
                    vals = rnorm(2500))
   v <- terra::as.polygons(r)
-  ext <- c("xmin" = -30, "xmax" = 10, "ymin" = -30, "ymax" = 10)
+  ext <- c("xmin" = -123.7835, "xmax" = -123.6352,
+           "ymin" = 41.7534, "ymax" = 41.8042)
 
   expect_equal(getAOI(r), ext)
   expect_equal(getAOI(v), ext)

--- a/tests/testthat/test-getAOI.R
+++ b/tests/testthat/test-getAOI.R
@@ -5,8 +5,7 @@ test_that("`getAOI` works with supported object classes", {
                    crs = terra::crs("epsg:4326"),
                    vals = rnorm(2500))
   v <- terra::as.polygons(r)
-  ext <- c("xmin" = -123.7835, "xmax" = -123.6352,
-           "ymin" = 41.7534, "ymax" = 41.8042)
+  ext <- c(-123.7835, 41.7534, -123.6352, 41.8042)
 
   expect_equal(getAOI(r), ext)
   expect_equal(getAOI(v), ext)


### PR DESCRIPTION
Fixed issues with: 
- `getAOI()` returning values in wrong order
- Prevent API error when resolution is set to `30` by user
- Fix documentation formatting
- Update `testthat`